### PR TITLE
Add TikTok place deletion with long press gesture

### DIFF
--- a/loc/Services/UserService.swift
+++ b/loc/Services/UserService.swift
@@ -449,6 +449,34 @@ class UserService: ObservableObject {
             }
         }
     }
+    
+    func deleteTikTokPlace(userId: String, placeId: String, completion: @escaping (Bool, Error?) -> Void) {
+        // Reference to the user's external places collection (TikTok imports)
+        let externalPlacesRef = db.collection("users")
+            .document(userId)
+            .collection("externalPlaces")
+            .document(placeId)
+        
+        // Delete the document from the user's external places collection
+        externalPlacesRef.delete { error in
+            if let error = error {
+                print("❌ [UserService] Error deleting TikTok place from user's collection: \(error.localizedDescription)")
+                completion(false, error)
+            } else {
+                print("✅ [UserService] TikTok place successfully deleted from user's collection")
+                // Also remove the user's association from the aggregated mapPlaces document
+                self.removeUserFromMapPlace(userId: userId, placeId: placeId) { success, error in
+                    if let error = error {
+                        print("❌ [UserService] Error removing user from mapPlace after TikTok deletion: \(error.localizedDescription)")
+                        completion(false, error)
+                    } else {
+                        print("✅ [UserService] User successfully removed from mapPlace after TikTok deletion")
+                        completion(true, nil)
+                    }
+                }
+            }
+        }
+    }
 
     func removeUserFromMapPlace(userId: String, placeId: String, completion: @escaping (Bool, Error?) -> Void) {
         // Reference to the mapPlaces document for the given place.

--- a/loc/ViewModels/ProfileViewModel.swift
+++ b/loc/ViewModels/ProfileViewModel.swift
@@ -613,6 +613,94 @@ class ProfileViewModel: ObservableObject {
     
     var hasMoreTikTokPlaces: Bool { _hasMoreTikTokPlaces }
     
+    // MARK: - TikTok Place Deletion
+    
+    func deleteTikTokPlace(_ place: DetailPlace, completion: @escaping (Bool) -> Void) {
+        guard let userId = user?.id else {
+            completion(false)
+            return
+        }
+        
+        let placeId = place.id.uuidString
+        
+        // Remove from local state first (optimistic update)
+        if let index = allTikTokPlaceIds.firstIndex(of: placeId) {
+            allTikTokPlaceIds.remove(at: index)
+        }
+        if let index = loadedTikTokPlaceIds.firstIndex(of: placeId) {
+            loadedTikTokPlaceIds.remove(at: index)
+        }
+        
+        // Remove from userExternalPlaces
+        userExternalPlaces.removeValue(forKey: placeId)
+        
+        // Remove from placeSavers (so it doesn't appear on map)
+        if var savers = detailPlaceViewModel.placeSavers[placeId] {
+            savers.removeAll { $0 == userId }
+            if savers.isEmpty {
+                detailPlaceViewModel.placeSavers.removeValue(forKey: placeId)
+            } else {
+                detailPlaceViewModel.placeSavers[placeId] = savers
+            }
+        }
+        
+        // Remove from places dictionary
+        detailPlaceViewModel.places.removeValue(forKey: placeId)
+        
+        // Recalculate map annotations
+        detailPlaceViewModel.calculateAnnotationPlaces()
+        
+        // Call backend to delete the TikTok place
+        userService.deleteTikTokPlace(userId: userId, placeId: placeId) { [weak self] success, error in
+            DispatchQueue.main.async {
+                if success {
+                    print("✅ [ProfileViewModel] Successfully deleted TikTok place: \(place.name)")
+                    completion(true)
+                } else {
+                    print("❌ [ProfileViewModel] Failed to delete TikTok place: \(error?.localizedDescription ?? "Unknown error")")
+                    
+                    // Revert optimistic update on failure
+                    self?.revertTikTokPlaceDeletion(place)
+                    completion(false)
+                }
+            }
+        }
+    }
+    
+    private func revertTikTokPlaceDeletion(_ place: DetailPlace) {
+        let placeId = place.id.uuidString
+        
+        // Re-add to local state
+        if !allTikTokPlaceIds.contains(placeId) {
+            allTikTokPlaceIds.append(placeId)
+            allTikTokPlaceIds.sort { placeId1, placeId2 in
+                // Sort by date (most recent first)
+                let place1 = userExternalPlaces[placeId1]
+                let place2 = userExternalPlaces[placeId2]
+                return (place1?.addedAt ?? Date.distantPast) > (place2?.addedAt ?? Date.distantPast)
+            }
+        }
+        
+        if !loadedTikTokPlaceIds.contains(placeId) {
+            loadedTikTokPlaceIds.append(placeId)
+        }
+        
+        // Re-add to placeSavers
+        if let userId = user?.id {
+            if detailPlaceViewModel.placeSavers[placeId] == nil {
+                detailPlaceViewModel.placeSavers[placeId] = [userId]
+            } else if !detailPlaceViewModel.placeSavers[placeId]!.contains(userId) {
+                detailPlaceViewModel.placeSavers[placeId]!.append(userId)
+            }
+        }
+        
+        // Re-add to places dictionary
+        detailPlaceViewModel.places[placeId] = place
+        
+        // Recalculate map annotations
+        detailPlaceViewModel.calculateAnnotationPlaces()
+    }
+    
     // MARK: - Reviewed Places Access
     
     /// Check if the current user has reviewed a specific place

--- a/loc/Views/MyProfileViews/MyPlacesListView.swift
+++ b/loc/Views/MyProfileViews/MyPlacesListView.swift
@@ -572,6 +572,8 @@ struct TikTokPlaceGridCell: View {
     let color: Color
     let externalPlace: ExternalPlace?
     
+    @State private var showDeleteConfirmation = false
+    
     // Get first TikTok thumbnail URL for this place
     private func getFirstTikTokThumbnail() -> String? {
         return externalPlace?.tiktokVideos.first?.thumbnailUrl
@@ -649,6 +651,23 @@ struct TikTokPlaceGridCell: View {
             selectedPlaceVM.selectedPlace = place
             selectedPlaceVM.isDetailSheetPresented = true
             presentationMode.wrappedValue.dismiss()
+        }
+        .onLongPressGesture {
+            showDeleteConfirmation = true
+        }
+        .alert("Delete TikTok Place", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) {
+                profile.deleteTikTokPlace(place) { success in
+                    if success {
+                        print("✅ Successfully deleted TikTok place: \(place.name)")
+                    } else {
+                        print("❌ Failed to delete TikTok place: \(place.name)")
+                    }
+                }
+            }
+        } message: {
+            Text("Are you sure you want to delete \"\(place.name)\"? This action cannot be undone.")
         }
     }
 } 


### PR DESCRIPTION
- Add deleteTikTokPlace method to ProfileViewModel with optimistic updates
- Add deleteTikTokPlace method to UserService for backend deletion
- Add long press gesture to TikTokPlaceGridCell to trigger deletion
- Add confirmation dialog with destructive action styling
- Implement proper state management and rollback on failure
- Remove place from all local collections (userExternalPlaces, placeSavers, etc.)
- Recalculate map annotations after deletion
- Maintain proper pagination state after deletion

Users can now long press on any saved TikTok place in the My Places popup to delete it with a confirmation dialog.