### PR TITLE
Remove menu and call buttons from DetailPlaceView

### DIFF
--- a/loc/Views/PlaceDetailViews/MaxPlaceDetailView.swift
+++ b/loc/Views/PlaceDetailViews/MaxPlaceDetailView.swift
@@ -14,56 +14,8 @@ struct MaxPlaceDetailView: View {
     // Accept callback for photo tapped
     let onPhotoTapped: ([UIImage], Int) -> Void
     
-    // 1) A state to track when we have no phone number
-    @Binding var showNoPhoneNumberAlert: Bool
-    
     var body: some View {
         VStack(spacing: 16) {
-            HStack(alignment: .center, spacing: 15) {
-                // CALL Bubble
-                Button(action: {
-                    // Check if phoneNumber is non-nil and not empty
-                    if let phoneNumber = selectedPlaceVM.selectedPlace?.phone,
-                       !phoneNumber.isEmpty,
-                       let url = URL(string: "tel://\(phoneNumber)") {
-                        UIApplication.shared.open(url)
-                    } else {
-                        showNoPhoneNumberAlert = true
-                    }
-                }) {
-                    HStack(spacing: 8) {
-                        Image(systemName: "phone")
-                            .font(.subheadline)
-                            .foregroundColor(.black)
-                        Text("CALL")
-                            .font(.subheadline)
-                            .foregroundColor(.black)
-                    }
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 8)
-                    .background(Color.gray.opacity(0.2))
-                    .clipShape(Capsule())
-                }
-
-                // MENU Bubble
-                HStack(spacing: 8) {
-                    Image(systemName: "fork.knife.circle")
-                        .font(.subheadline)
-                        .foregroundColor(.black)
-                    Text("MENU")
-                        .font(.subheadline)
-                        .foregroundColor(.black)
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(Color.gray.opacity(0.2))
-                .clipShape(Capsule())
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-            
-            Divider()
-                .padding(.top, 15)
-                .padding(.bottom, 15)
             
             Text("PHOTOS")
                 .font(.subheadline)

--- a/loc/Views/PlaceDetailViews/MinPlaceDetailView.swift
+++ b/loc/Views/PlaceDetailViews/MinPlaceDetailView.swift
@@ -216,8 +216,7 @@ struct MinPlaceDetailView: View {
                     
                     MaxPlaceDetailView(
                         viewModel: viewModel,
-                        onPhotoTapped: onPhotoTapped,
-                        showNoPhoneNumberAlert: $showNoPhoneNumberAlert
+                        onPhotoTapped: onPhotoTapped
                     )
                 case .reviews:
                     PlaceReviewsView(onPhotoTapped: onPhotoTapped)


### PR DESCRIPTION
- Removed CALL and MENU button section from MaxPlaceDetailView
- Cleaned up unused showNoPhoneNumberAlert binding
- Updated MinPlaceDetailView to remove unused parameter
- Simplified DetailPlaceView layout by removing entire button section