### PR TITLE
Fix About Place photos showing grey placeholders

### DIFF
--- a/loc/Views/PlaceDetailViews/AsyncPhotoItemView.swift
+++ b/loc/Views/PlaceDetailViews/AsyncPhotoItemView.swift
@@ -16,13 +16,16 @@ struct AsyncPhotoItemView: View {
     let cornerRadius: CGFloat
     var onLoadFailed: ((String) -> Void)? = nil
 
+    /// Tracks whether the size-optimized Google CDN URLs failed, triggering a raw-URL fallback.
+    @State private var progressiveLoadFailed = false
+
     private var isGoogleCDN: Bool {
         item.url.contains("lh3.googleusercontent.com")
     }
 
     var body: some View {
         Group {
-            if isGoogleCDN {
+            if isGoogleCDN && !progressiveLoadFailed {
                 progressiveGoogleImage
             } else {
                 standardImage
@@ -46,8 +49,8 @@ struct AsyncPhotoItemView: View {
                 case .success(let image):
                     image.resizable().scaledToFill()
                 case .failure:
-                    failedView
-                        .onAppear { onLoadFailed?(item.url) }
+                    Color.clear
+                        .onAppear { progressiveLoadFailed = true }
                 default:
                     ShimmerView()
                 }
@@ -60,7 +63,6 @@ struct AsyncPhotoItemView: View {
                         .transition(.opacity.animation(.easeIn(duration: 0.3)))
                 case .failure:
                     Color.clear
-                        .onAppear { onLoadFailed?(item.url) }
                 default:
                     Color.clear
                 }
@@ -85,6 +87,7 @@ struct AsyncPhotoItemView: View {
 
             case .failure:
                 failedView
+                    .onAppear { onLoadFailed?(item.url) }
 
             @unknown default:
                 ShimmerView()


### PR DESCRIPTION
## Summary
- Google CDN URL format changed — size-optimized URLs (=s400/=s1600) no longer work for some photos
- Added fallback in AsyncPhotoItemView that retries with the raw URL when progressive loading fails
- Matches the fullscreen viewer behavior which already worked

## Test plan
- [x] Navigate to place detail → About tab → photos load correctly
- [x] Tap photo → fullscreen viewer still works
- [x] Photos with old URL format still use progressive loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)