### PR TITLE
Make list search instant with local filtering

### DIFF
--- a/database_functions/get_all_user_list_metadata.sql
+++ b/database_functions/get_all_user_list_metadata.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- Function: get_all_user_list_metadata
+-- ============================================================================
+-- Returns lightweight metadata for ALL lists owned by a user.
+-- Used to power instant client-side list search — no pagination, no
+-- collaborator photos, no distance calc. Just the fields needed for
+-- filtering and display in search results.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_all_user_list_metadata(p_user_id text)
+RETURNS TABLE(
+    list_id text,
+    name text,
+    is_public boolean,
+    image text,
+    city text,
+    place_count bigint,
+    created_at text,
+    updated_at text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+AS $function$
+BEGIN
+    IF lower(p_user_id) != lower(auth.uid()::text) THEN
+        RAISE EXCEPTION 'unauthorized';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        pl.id::text AS list_id,
+        pl.name,
+        pl.is_public,
+        pl.image,
+        pl.city,
+        (SELECT COUNT(*) FROM place_list_items pli WHERE pli.list_id = pl.id) AS place_count,
+        pl.created_at::text,
+        pl.updated_at::text
+    FROM place_lists pl
+    WHERE pl.user_id = p_user_id
+    ORDER BY pl.updated_at DESC NULLS LAST;
+END;
+$function$;

--- a/loc/Services/PlaceListService.swift
+++ b/loc/Services/PlaceListService.swift
@@ -89,6 +89,22 @@ class PlaceListService {
         return lists
     }
     
+    // MARK: - All List Metadata
+
+    /// Fetches lightweight metadata for all lists owned by a user (for instant local search).
+    func fetchAllListMetadata(userId: String) async throws -> [LightweightPlaceList] {
+        struct Params: Encodable {
+            let p_user_id: String
+        }
+
+        let lists: [LightweightPlaceList] = try await supabase.client
+            .rpc("get_all_user_list_metadata", params: Params(p_user_id: userId))
+            .execute()
+            .value
+
+        return lists
+    }
+
     // MARK: - Fetch Places in List
     
     /// Fetch places within a specific place list with pagination

--- a/loc/ViewModels/Lists/ListsDataViewModel.swift
+++ b/loc/ViewModels/Lists/ListsDataViewModel.swift
@@ -24,6 +24,9 @@ class ListsDataViewModel: ObservableObject {
 
     // MARK: - Published Properties - Lightweight Format
 
+    /// All list metadata for instant local search.
+    @Published var allListsCache: [LightweightPlaceList] = []
+
     /// Lightweight place lists sorted by proximity.
     @Published var lightweightPlaceLists: [LightweightPlaceList] = []
 
@@ -107,6 +110,7 @@ class ListsDataViewModel: ObservableObject {
                 city: nil
             )
             lightweightPlaceLists.insert(lightweightList, at: 0)
+            allListsCache.insert(lightweightList, at: 0)
 
             // Refresh lightweight place lists to include the new list with proper sorting
             if let location = locationManager?.currentLocation?.coordinate {
@@ -143,6 +147,9 @@ class ListsDataViewModel: ObservableObject {
             if let index = lightweightPlaceLists.firstIndex(where: { $0.list_id == list.list_id }) {
                 lightweightPlaceLists[index].name = newName
             }
+            if let index = allListsCache.firstIndex(where: { $0.list_id == list.list_id }) {
+                allListsCache[index].name = newName
+            }
 
             return .success(())
         } catch {
@@ -173,6 +180,7 @@ class ListsDataViewModel: ObservableObject {
 
             // Remove from local state
             lightweightPlaceLists.removeAll { $0.list_id == list.list_id }
+            allListsCache.removeAll { $0.list_id == list.list_id }
             lightweightPlaceListPlaces.removeValue(forKey: list.list_id)
             lightweightPlaceListCounts.removeValue(forKey: list.list_id)
 
@@ -301,6 +309,7 @@ class ListsDataViewModel: ObservableObject {
         userLists.removeAll()
         userListsPlaces.removeAll()
         placeListCounts.removeAll()
+        allListsCache.removeAll()
         lightweightPlaceLists.removeAll()
         lightweightPlaceListPlaces.removeAll()
         lightweightPlaceListCounts.removeAll()

--- a/loc/ViewModels/Lists/ListsLoadingViewModel.swift
+++ b/loc/ViewModels/Lists/ListsLoadingViewModel.swift
@@ -25,9 +25,10 @@ class ListsLoadingViewModel: ObservableObject {
     private weak var userSession: UserSession?
     private weak var locationManager: LocationManager?
 
-    // MARK: - Data ViewModel Reference
+    // MARK: - ViewModel References
 
     private weak var dataViewModel: ListsDataViewModel?
+    private weak var searchViewModel: ListsSearchViewModel?
 
     // MARK: - Callbacks
 
@@ -44,6 +45,11 @@ class ListsLoadingViewModel: ObservableObject {
         self.dataViewModel = dataViewModel
     }
 
+    /// Sets the search view model reference (called after init to avoid circular dependency).
+    func setSearchViewModel(_ searchVM: ListsSearchViewModel) {
+        self.searchViewModel = searchVM
+    }
+
     // MARK: - List Loading (Primary Data Flow)
 
     /// Loads the initial page of lists with proximity sorting and shared lists.
@@ -56,6 +62,9 @@ class ListsLoadingViewModel: ObservableObject {
 
         let pageSize = 6
         let userLocation = locationManager?.currentLocation?.coordinate
+
+        // Fetch all list metadata (for instant search) in parallel with paginated lists
+        async let allMetaTask: [LightweightPlaceList] = fetchAllListMetadata(userId: userId)
 
         // Fetch owned lists - use proximity sorting if location available
         var ownedLists: [LightweightPlaceList] = []
@@ -77,6 +86,10 @@ class ListsLoadingViewModel: ObservableObject {
             print("⚠️ [ListsLoadingViewModel] No user location available - loading lists without proximity sorting")
             ownedLists = await fetchListsWithoutLocation(userId: userId, pageSize: pageSize)
         }
+
+        // Store all metadata cache (for instant search)
+        let allMeta = await allMetaTask
+        dataVM.allListsCache = allMeta
 
         // Fetch shared and collaborative lists in parallel
         var sharedLists: [SharedListInfo] = []
@@ -109,8 +122,12 @@ class ListsLoadingViewModel: ObservableObject {
         // Merge: owned (paginated) + collaborative owned (not in page 1) + shared with me
         let allLists = ownedLists + additionalCollaborativeLists + sharedAsLightweight
 
-        // Update state
-        dataVM.lightweightPlaceLists = allLists
+        // Only overwrite displayed lists if user hasn't started searching
+        let isSearchActive = !(searchViewModel?.listSearchText.trimmingCharacters(in: .whitespaces).isEmpty ?? true)
+        if !isSearchActive {
+            dataVM.lightweightPlaceLists = allLists
+        }
+
         dataVM.placeListsCurrentPage = 1
         dataVM.hasMorePlaceLists = ownedLists.count >= pageSize
         dataVM.initializePlaceCountsFromMetadata(for: allLists)
@@ -182,6 +199,16 @@ class ListsLoadingViewModel: ObservableObject {
             await loadPlacesForLists(lists)
         } catch {
             print("❌ [ListsLoadingViewModel] Error loading place lists by coordinates: \(error.localizedDescription)")
+        }
+    }
+
+    /// Fetches lightweight metadata for all user lists (powers instant local search).
+    private func fetchAllListMetadata(userId: String) async -> [LightweightPlaceList] {
+        do {
+            return try await PlaceListService.shared.fetchAllListMetadata(userId: userId)
+        } catch {
+            print("❌ [ListsLoadingViewModel] Error fetching all list metadata: \(error)")
+            return []
         }
     }
 

--- a/loc/ViewModels/Lists/ListsSearchViewModel.swift
+++ b/loc/ViewModels/Lists/ListsSearchViewModel.swift
@@ -74,53 +74,31 @@ class ListsSearchViewModel: ObservableObject {
 
     // MARK: - Search
 
-    /// Performs server-side search across all user lists.
+    /// Filters lists locally against the pre-fetched metadata cache for instant results.
     func performListSearch() async {
-        guard let userId = userSession?.currentUserId,
-              let dataVM = dataViewModel else { return }
+        guard let dataVM = dataViewModel,
+              let loadingVM = loadingViewModel else { return }
 
         let searchTerm = listSearchText.trimmingCharacters(in: .whitespaces)
         guard !searchTerm.isEmpty else { return }
 
-        do {
-            let searchResults = try await PlaceListService.shared.searchListsByName(
-                userId: userId,
-                searchTerm: listSearchText
-            )
+        // Local filtering — instant, no network call
+        let results = dataVM.allListsCache.filter {
+            $0.name.localizedCaseInsensitiveContains(searchTerm)
+        }
 
-            dataVM.lightweightPlaceLists = searchResults
+        dataVM.lightweightPlaceLists = results
 
-            for list in searchResults {
-                if dataVM.lightweightPlaceListCounts[list.list_id] == nil {
-                    dataVM.lightweightPlaceListCounts[list.list_id] = list.place_count
-                }
+        for list in results {
+            if dataVM.lightweightPlaceListCounts[list.list_id] == nil {
+                dataVM.lightweightPlaceListCounts[list.list_id] = list.place_count
             }
+        }
 
-            // Load places for search results
-            await withTaskGroup(of: (String, [LightweightPlace]?).self) { group in
-                for list in searchResults {
-                    group.addTask {
-                        do {
-                            let places = try await self.userService.fetchPlacesForPlaceList(
-                                listId: list.list_id,
-                                page: 1,
-                                pageSize: 6
-                            )
-                            return (list.list_id, places)
-                        } catch {
-                            return (list.list_id, nil)
-                        }
-                    }
-                }
-
-                for await (listId, places) in group {
-                    if let places = places {
-                        dataVM.setPlacesForList(listId: listId, places: places)
-                    }
-                }
-            }
-        } catch {
-            print("❌ [ListsSearchViewModel] Error searching lists: \(error)")
+        // Load places for results that don't already have cached places
+        let uncachedResults = results.filter { dataVM.lightweightPlaceListPlaces[$0.list_id] == nil }
+        if !uncachedResults.isEmpty {
+            await loadingVM.loadPlacesForLists(uncachedResults)
         }
     }
 

--- a/loc/ViewModels/ProfileListsViewModel.swift
+++ b/loc/ViewModels/ProfileListsViewModel.swift
@@ -255,6 +255,7 @@ class ProfileListsViewModel: ObservableObject {
         mutationsVM.setDistanceSortingViewModel(distanceSortingVM)
         mutationsVM.setPlacePaginationViewModel(placePaginationVM)
         legacyLoadingVM.setPlacePaginationViewModel(placePaginationVM)
+        loadingVM.setSearchViewModel(searchVM)
 
         // Wire up data ViewModel callback
         dataVM.onSortListsByDistance = { [weak distanceSortingVM] in

--- a/loc/ViewModels/ProfileViewModel.swift
+++ b/loc/ViewModels/ProfileViewModel.swift
@@ -299,7 +299,7 @@ class ProfileViewModel: ObservableObject {
     private func setupListSearchObserver() {
         listSearchCancellable = listsViewModel.searchViewModel.$listSearchText
             .dropFirst()
-            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
             .removeDuplicates()
             .sink { [weak self] (text: String) in
                 Task { @MainActor [weak self] in

--- a/loc/Views/MyProfileViews/ProfileViewListsView.swift
+++ b/loc/Views/MyProfileViews/ProfileViewListsView.swift
@@ -156,10 +156,13 @@ struct ProfileViewListsView: View {
     
     @ViewBuilder
     private var listContent: some View {
-        if listsVM.isLoadingInitialLists {
+        let hasSearchText = !listsVM.listSearchText.trimmingCharacters(in: .whitespaces).isEmpty
+        if listsVM.isLoadingInitialLists && !hasSearchText {
             initialLoadingView
         } else if !listsVM.filteredPlaceLists.isEmpty {
             listView
+        } else if hasSearchText {
+            noSearchResultsView
         } else {
             emptyStateView
         }
@@ -254,6 +257,16 @@ struct ProfileViewListsView: View {
         }
     }
     
+    private var noSearchResultsView: some View {
+        VStack(spacing: 8) {
+            Text("No matching lists")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 30)
+    }
+
     private var noSharedListsView: some View {
         VStack(spacing: 12) {
             Image(systemName: "person.2")


### PR DESCRIPTION
## Summary
- Pre-fetches all list metadata at profile load for instant local search
- Eliminates race condition where initial load overwrote search results
- Removes per-keystroke server calls, debounce reduced 300ms → 100ms

## Test plan
- [x] Search lists immediately on profile open before cards load
- [x] Clear search restores paginated view
- [x] Create/rename/delete list stays in sync with search cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)