### PR TITLE
Performance: annotation caching, list loading, and UX improvements

### DIFF
--- a/database_functions/get_all_user_list_metadata.sql
+++ b/database_functions/get_all_user_list_metadata.sql
@@ -16,7 +16,8 @@ RETURNS TABLE(
     city text,
     place_count bigint,
     created_at text,
-    updated_at text
+    updated_at text,
+    preview_photos text[]
 )
 LANGUAGE plpgsql
 STABLE
@@ -36,8 +37,19 @@ BEGIN
         pl.city,
         (SELECT COUNT(*) FROM place_list_items pli WHERE pli.list_id = pl.id) AS place_count,
         pl.created_at::text,
-        pl.updated_at::text
+        pl.updated_at::text,
+        pp.photos AS preview_photos
     FROM place_lists pl
+    LEFT JOIN LATERAL (
+        SELECT ARRAY_AGG(photo) AS photos FROM (
+            SELECT get_latest_review_photo(pli.place_id) AS photo
+            FROM place_list_items pli
+            WHERE pli.list_id = pl.id
+            ORDER BY pli.sort_order ASC NULLS LAST
+            LIMIT 3
+        ) sub
+        WHERE sub.photo IS NOT NULL
+    ) pp ON true
     WHERE pl.user_id = p_user_id
     ORDER BY pl.updated_at DESC NULLS LAST;
 END;

--- a/database_functions/get_paginated_user_place_lists_by_proximity.sql
+++ b/database_functions/get_paginated_user_place_lists_by_proximity.sql
@@ -27,7 +27,7 @@ RETURNS TABLE(
     collaborator_photos TEXT[],
     description TEXT,
     city TEXT,
-    price_tier TEXT
+    preview_photos TEXT[]
 )
  LANGUAGE plpgsql
  SECURITY DEFINER
@@ -49,18 +49,18 @@ BEGIN
         combined.collaborator_photos,
         combined.description,
         combined.city,
-        combined.price_tier
+        combined.preview_photos
     FROM (
         -- Lists WITH average_location (sorted by proximity)
-    SELECT
-        pl.id::TEXT AS list_id,
-        pl.name,
-        ST_AsText(pl.average_location) AS average_location,
-        pl.is_public,
-        pl.image,
-        pl.created_at,
-        pl.updated_at,
-        ST_Distance(pl.average_location, p_user_location) AS distance_meters,
+        SELECT
+            pl.id::TEXT AS list_id,
+            pl.name,
+            ST_AsText(pl.average_location) AS average_location,
+            pl.is_public,
+            pl.image,
+            pl.created_at,
+            pl.updated_at,
+            ST_Distance(pl.average_location, p_user_location) AS distance_meters,
             (SELECT COUNT(*) FROM place_list_items pli WHERE pli.list_id = pl.id) AS place_count,
             (SELECT COUNT(*) FROM place_list_collaborators plc WHERE plc.list_id = pl.id) AS collaborator_count,
             (
@@ -75,11 +75,21 @@ BEGIN
             ) AS collaborator_photos,
             pl.description,
             pl.city,
-            pl.price_tier,
-            0 AS sort_order  -- Lists with location come first
-    FROM place_lists pl
-    WHERE pl.user_id = p_user_id
-        AND pl.average_location IS NOT NULL
+            pp.photos AS preview_photos,
+            0 AS sort_order
+        FROM place_lists pl
+        LEFT JOIN LATERAL (
+            SELECT ARRAY_AGG(photo) AS photos FROM (
+                SELECT get_latest_review_photo(pli.place_id) AS photo
+                FROM place_list_items pli
+                WHERE pli.list_id = pl.id
+                ORDER BY pli.sort_order ASC NULLS LAST
+                LIMIT 3
+            ) sub
+            WHERE sub.photo IS NOT NULL
+        ) pp ON true
+        WHERE pl.user_id = p_user_id
+            AND pl.average_location IS NOT NULL
 
         UNION ALL
 
@@ -92,7 +102,7 @@ BEGIN
             pl.image,
             pl.created_at,
             pl.updated_at,
-            NULL::DOUBLE PRECISION AS distance_meters,  -- No distance for lists without location
+            NULL::DOUBLE PRECISION AS distance_meters,
             (SELECT COUNT(*) FROM place_list_items pli WHERE pli.list_id = pl.id) AS place_count,
             (SELECT COUNT(*) FROM place_list_collaborators plc WHERE plc.list_id = pl.id) AS collaborator_count,
             (
@@ -107,9 +117,19 @@ BEGIN
             ) AS collaborator_photos,
             pl.description,
             pl.city,
-            pl.price_tier,
-            1 AS sort_order  -- Lists without location come after
+            pp.photos AS preview_photos,
+            1 AS sort_order
         FROM place_lists pl
+        LEFT JOIN LATERAL (
+            SELECT ARRAY_AGG(photo) AS photos FROM (
+                SELECT get_latest_review_photo(pli.place_id) AS photo
+                FROM place_list_items pli
+                WHERE pli.list_id = pl.id
+                ORDER BY pli.sort_order ASC NULLS LAST
+                LIMIT 3
+            ) sub
+            WHERE sub.photo IS NOT NULL
+        ) pp ON true
         WHERE pl.user_id = p_user_id
             AND pl.average_location IS NULL
     ) combined

--- a/loc/Models/LightweightPlaceList.swift
+++ b/loc/Models/LightweightPlaceList.swift
@@ -34,6 +34,9 @@ struct LightweightPlaceList: Identifiable {
     var user_role: String?
     var collaborator_photos: [String]?
 
+    /// Preview photo URLs for list card collage (top 3 places' review photos, embedded in list RPC).
+    var preview_photos: [String]?
+
     var id: String { list_id }
 
     /// Whether this list requires purchase to access full content
@@ -97,7 +100,8 @@ struct LightweightPlaceList: Identifiable {
         owner_name: String? = nil,
         owner_photo_url: String? = nil,
         user_role: String? = nil,
-        collaborator_photos: [String]? = nil
+        collaborator_photos: [String]? = nil,
+        preview_photos: [String]? = nil
     ) {
         self.list_id = list_id
         self.name = name
@@ -117,6 +121,7 @@ struct LightweightPlaceList: Identifiable {
         self.owner_photo_url = owner_photo_url
         self.user_role = user_role
         self.collaborator_photos = collaborator_photos
+        self.preview_photos = preview_photos
     }
 }
 
@@ -142,6 +147,7 @@ extension LightweightPlaceList: Codable {
         case owner_photo_url
         case user_role
         case collaborator_photos
+        case preview_photos
     }
 
     init(from decoder: Decoder) throws {
@@ -183,6 +189,7 @@ extension LightweightPlaceList: Codable {
         owner_photo_url = try container.decodeIfPresent(String.self, forKey: .owner_photo_url)
         user_role = try container.decodeIfPresent(String.self, forKey: .user_role)
         collaborator_photos = try container.decodeIfPresent([String].self, forKey: .collaborator_photos)
+        preview_photos = try container.decodeIfPresent([String].self, forKey: .preview_photos)
     }
 
     /// Small Decodable for parsing PostGIS GeoJSON format: {"type":"Point","coordinates":[lon,lat]}
@@ -214,5 +221,6 @@ extension LightweightPlaceList: Codable {
         try container.encodeIfPresent(owner_photo_url, forKey: .owner_photo_url)
         try container.encodeIfPresent(user_role, forKey: .user_role)
         try container.encodeIfPresent(collaborator_photos, forKey: .collaborator_photos)
+        try container.encodeIfPresent(preview_photos, forKey: .preview_photos)
     }
 }

--- a/loc/ViewModels/Lists/ListsLoadingViewModel.swift
+++ b/loc/ViewModels/Lists/ListsLoadingViewModel.swift
@@ -60,7 +60,7 @@ class ListsLoadingViewModel: ObservableObject {
         isLoadingInitialLists = true
         defer { isLoadingInitialLists = false }
 
-        let pageSize = 6
+        let pageSize = 12 // Covers full screen in 2-column grid without immediate pagination
         let userLocation = locationManager?.currentLocation?.coordinate
 
         // Fetch all list metadata (for instant search) in parallel with paginated lists
@@ -132,9 +132,11 @@ class ListsLoadingViewModel: ObservableObject {
         dataVM.hasMorePlaceLists = ownedLists.count >= pageSize
         dataVM.initializePlaceCountsFromMetadata(for: allLists)
 
-        // Load places for each list
-        if !allLists.isEmpty {
-            await loadPlacesForLists(allLists)
+        // Load places only for lists without preview photos (shared/collaborative lists)
+        // Owned lists already have preview_photos embedded in the RPC response
+        let listsNeedingPlaces = allLists.filter { ($0.preview_photos ?? []).isEmpty && $0.place_count > 0 }
+        if !listsNeedingPlaces.isEmpty {
+            await loadPlacesForLists(listsNeedingPlaces)
         }
     }
 
@@ -150,7 +152,7 @@ class ListsLoadingViewModel: ObservableObject {
         defer { isLoadingMorePlaceLists = false }
 
         let nextPage = dataVM.placeListsCurrentPage + 1
-        let pageSize = 6
+        let pageSize = 12
 
         do {
             let moreLists = try await userService.fetchPlaceListsByProximity(
@@ -163,10 +165,6 @@ class ListsLoadingViewModel: ObservableObject {
 
             dataVM.appendPlaceLists(moreLists, nextPage: nextPage, pageSize: pageSize)
             dataVM.initializePlaceCountsFromMetadata(for: moreLists)
-
-            if !moreLists.isEmpty {
-                await loadPlacesForLists(moreLists)
-            }
         } catch {
             print("❌ [ListsLoadingViewModel] Error loading more place lists: \(error.localizedDescription)")
         }

--- a/loc/ViewModels/Map/MapPhotoViewModel.swift
+++ b/loc/ViewModels/Map/MapPhotoViewModel.swift
@@ -98,15 +98,21 @@ class MapPhotoViewModel: ObservableObject {
 
     // MARK: - Annotation Image Generation
 
-    /// Generates combined annotation images off the main thread, cancelling any in-flight generation.
+    /// Generates combined annotation images off the main thread, merging into the existing cache.
     func generateAnnotationImages(for annotations: [PlaceAnnotation]) {
         currentGenerationTask?.cancel()
         let pictures = self.userProfilePictures
+        let existingKeys = Set(annotationImages.keys)
+        // Only render images for annotations that don't already have a cached image
+        let newAnnotations = annotations.filter { !existingKeys.contains($0.id) }
+        guard !newAnnotations.isEmpty else { return }
+
         currentGenerationTask = Task.detached(priority: .userInitiated) {
-            let images = Self.renderAnnotationImages(for: annotations, profilePictures: pictures)
+            let images = Self.renderAnnotationImages(for: newAnnotations, profilePictures: pictures)
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
-                self?.annotationImages = images
+                guard let self else { return }
+                self.annotationImages.merge(images) { _, new in new }
             }
         }
     }

--- a/loc/ViewModels/Map/MapViewportViewModel.swift
+++ b/loc/ViewModels/Map/MapViewportViewModel.swift
@@ -14,6 +14,21 @@ class MapViewportViewModel: ObservableObject {
     @Published var communityMarkers: [CommunityPlaceMarker] = []
     @Published var isLoadingViewportPlaces: Bool = false
 
+    /// Accumulated annotation cache keyed by place ID for deduplication.
+    private var annotationCache: [String: PlaceAnnotation] = [:]
+
+    /// Accumulated community marker cache keyed by place ID.
+    private var communityMarkerCache: [String: CommunityPlaceMarker] = [:]
+
+    /// Regions already fetched — used to skip redundant server calls.
+    private var loadedRegions: [MKCoordinateRegion] = []
+
+    /// Timestamp of last full cache refresh.
+    private var lastRefreshTime: Date = .distantPast
+
+    /// Interval between full cache refreshes (5 minutes).
+    private let refreshInterval: TimeInterval = 300
+
     private var debounceTimer: Timer?
     private var lastLoadedRegion: MKCoordinateRegion?
     private var placeDetailsCache: [String: DetailPlace] = [:]
@@ -39,20 +54,40 @@ class MapViewportViewModel: ObservableObject {
         userId: String,
         filterState: MapFilterState
     ) async {
+        // Check if data is stale and needs a full refresh
+        if Date().timeIntervalSince(lastRefreshTime) > refreshInterval {
+            clearAnnotations()
+            lastLoadedRegion = nil
+        }
+
         if let lastRegion = lastLoadedRegion, !shouldReloadForRegion(newRegion, lastRegion: lastRegion) {
+            return
+        }
+
+        // Skip if this region is already fully covered by previously loaded regions
+        if isRegionCovered(newRegion) {
+            lastLoadedRegion = newRegion
             return
         }
 
         await loadPlacesForViewport(newRegion, userId: userId, filterState: filterState)
     }
 
-    /// Resets the last loaded region to force a reload on next camera settle.
+    /// Resets the last loaded region and clears cached data to force a full reload.
     func resetLastLoadedRegion() {
         lastLoadedRegion = nil
+        annotationCache.removeAll()
+        communityMarkerCache.removeAll()
+        loadedRegions.removeAll()
+        viewportAnnotations = []
+        communityMarkers = []
     }
 
-    /// Clears all annotations and markers.
+    /// Clears all cached annotations, markers, and loaded regions (used on filter changes).
     func clearAnnotations() {
+        annotationCache.removeAll()
+        communityMarkerCache.removeAll()
+        loadedRegions.removeAll()
         viewportAnnotations = []
         communityMarkers = []
     }
@@ -170,17 +205,27 @@ class MapViewportViewModel: ObservableObject {
                     return
                 }
 
-                self.viewportAnnotations = annotations
+                // Merge new annotations into cache (accumulate, don't replace)
+                for annotation in annotations {
+                    annotationCache[annotation.id] = annotation
+                }
 
-                // Filter out community markers that overlap with friends annotations
-                let friendsPlaceIds = Set(annotations.map { $0.id })
-                let filteredCommunity = community.filter { !friendsPlaceIds.contains($0.id) }
+                // Merge community markers, excluding those that overlap with friend annotations
+                let friendsPlaceIds = Set(annotationCache.keys)
+                for marker in community where !friendsPlaceIds.contains(marker.id) {
+                    communityMarkerCache[marker.id] = marker
+                }
 
-                self.communityMarkers = filteredCommunity
                 self.lastLoadedRegion = region
+                self.loadedRegions.append(region)
+                if loadedRegions.count == 1 { self.lastRefreshTime = Date() }
+
+                // Publish updated arrays from cache
+                self.viewportAnnotations = Array(annotationCache.values)
+                self.communityMarkers = Array(communityMarkerCache.values)
 
                 // Notify parent to regenerate annotation images
-                onAnnotationsLoaded?(annotations)
+                onAnnotationsLoaded?(self.viewportAnnotations)
 
             } catch {
                 let isCancelled = Task.isCancelled || error is CancellationError || (error as NSError).code == NSURLErrorCancelled
@@ -319,6 +364,19 @@ class MapViewportViewModel: ObservableObject {
             eastLng: centerLng + (lngDelta / 2),
             westLng: centerLng - (lngDelta / 2)
         )
+    }
+
+    /// Checks if the new region is fully contained within any previously loaded region.
+    private func isRegionCovered(_ region: MKCoordinateRegion) -> Bool {
+        let newBounds = getViewportBounds(from: region)
+
+        return loadedRegions.contains { loaded in
+            let b = getViewportBounds(from: loaded)
+            return newBounds.northLat <= b.northLat &&
+                   newBounds.southLat >= b.southLat &&
+                   newBounds.eastLng <= b.eastLng &&
+                   newBounds.westLng >= b.westLng
+        }
     }
 
     /// Checks if region change is significant enough to reload.

--- a/loc/ViewModels/MapViewModel.swift
+++ b/loc/ViewModels/MapViewModel.swift
@@ -254,6 +254,12 @@ class MapViewModel: ObservableObject {
         }
     }
 
+    /// Invalidates the annotation cache so the next camera settle triggers a fresh fetch.
+    /// Call this after user actions that create new annotation data (add place, favorite, review, etc.).
+    func invalidateAnnotations() {
+        viewportViewModel.resetLastLoadedRegion()
+    }
+
     /// Clears all special filters (list, external places, reviews, favorites, my places, external).
     func clearAllFilters() {
         filteringViewModel.clearAllFilters()

--- a/loc/ViewModels/PlaceDetailTabsViewModel.swift
+++ b/loc/ViewModels/PlaceDetailTabsViewModel.swift
@@ -301,28 +301,42 @@ class PlaceDetailTabsViewModel: ObservableObject {
         // If photos weren't loaded yet (placeholder UUID was skipped), load now with the real UUID
         if let place = place, placePhotosViewModel.externalPhotoItems.isEmpty,
            !place.hasPlaceholderID {
+            // Clear stale state before loading with real UUID to prevent flash of old data
+            hasPosts = false
+            postCount = 0
+            showSaversIndicator = false
+            saverCount = 0
+
             placePhotosViewModel.setPlace(place)
             placeSaversViewModel.setPlace(place.id.uuidString)
+            postsViewModel.setPlace(place)
         }
     }
 
     /// Called by View when selected place changes.
     func setPlace(_ place: DetailPlace?) {
-        // Setting currentPlace triggers the reactive subscription automatically
-        handlePlaceChanged(place)
-
-        // Immediately clear stale savers from previous place (before child VM fetches new data)
+        // Clear all stale display state BEFORE updating currentPlace
+        // This prevents the reactive CombineLatest subscription from briefly
+        // showing cached data from a previous visit to the same place
+        hasPosts = false
+        postCount = 0
         showSaversIndicator = false
         saverCount = 0
+        placeRating = 0
 
-        // Update all child ViewModels with new place
+        // Reset child VMs before setting currentPlace (prevents stale data flash)
+        postsViewModel.setPlace(place)
+        placePhotosViewModel.setPlace(place)
+        placeSaversViewModel.setPlace(place?.id.uuidString)
+
+        // Now update currentPlace — triggers reactive subscription with clean state
+        handlePlaceChanged(place)
+
+        // Update remaining child ViewModels
         travelTimeViewModel.setPlace(place)
         openStatusViewModel.setPlace(place)
-        placeSaversViewModel.setPlace(place?.id.uuidString)
         notesTabViewModel.setPlace(place)
-        placePhotosViewModel.setPlace(place)
         aboutTabViewModel.setPlace(place)
-        postsViewModel.setPlace(place)
 
         // Check place list membership
         Task {

--- a/loc/ViewModels/ProfileViewModel.swift
+++ b/loc/ViewModels/ProfileViewModel.swift
@@ -746,6 +746,9 @@ class ProfileViewModel: ObservableObject {
         invalidateProfileCounts()
         await loadProfileCounts()
 
+        // Invalidate map annotation cache so next camera settle picks up any new data
+        mapViewModel?.invalidateAnnotations()
+
         if !isCuratedProfile {
             async let reviews: Void = reviewsViewModel.refreshReviewedPlaces()
             async let externalPlaces: Void = externalContentViewModel.reloadLightweightExternalPlaces()

--- a/loc/Views/Containers/MapContainerView.swift
+++ b/loc/Views/Containers/MapContainerView.swift
@@ -149,6 +149,8 @@ struct MapContainerView: View {
             .environmentObject(detailPlaceViewModel)
             .environmentObject(profileViewModel)
             .environmentObject(mapDisplayCoordinatorViewModel)
+            .environmentObject(userProfileNavigationViewModel)
+            .environmentObject(userSession)
             .onChange(of: profileViewModel.selectedListIdForMap) { oldValue, newValue in
                 handleListSelectionChange(newValue)
             }

--- a/loc/Views/Containers/MapContainerView.swift
+++ b/loc/Views/Containers/MapContainerView.swift
@@ -165,6 +165,11 @@ struct MapContainerView: View {
                 handleMyPlacesOnMap(newValue)
             }
             .onChange(of: presentationService.activeSheet) { oldSheet, newSheet in
+                // Clear selection state when place detail sheet is dismissed
+                if newSheet == nil, oldSheet == .placeDetail {
+                    selectedPlaceViewModel.selectedPlace = nil
+                }
+
                 // Clear trip annotations when the trips sheet is dismissed
                 if newSheet == nil, oldSheet == .tripsList {
                     mapDisplayCoordinatorViewModel.clearTripAnnotations()

--- a/loc/Views/CustomPlaceAnnotationView.swift
+++ b/loc/Views/CustomPlaceAnnotationView.swift
@@ -22,20 +22,18 @@ struct CustomPlaceAnnotationView: View {
         VStack(spacing: 2) {
             if let annotationImage = annotationImage {
                 Image(uiImage: annotationImage)
+                    .interpolation(.medium)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 60, height: 30)
-                    .shadow(color: isSelected ? Color.blue.opacity(0.8) : .clear, radius: 15)
-                    .shadow(color: isSelected ? Color.blue.opacity(0.5) : .clear, radius: 25)
-                    .shadow(color: isSelected ? Color.blue.opacity(0.3) : .clear, radius: 35)
+                    .compositingGroup()
                     .shadow(
-                        color: Color.black.opacity(isSelected ? 0.5 : 0.3),
-                        radius: isSelected ? 8 : 4,
+                        color: isSelected ? Color.blue.opacity(0.6) : Color.black.opacity(0.3),
+                        radius: isSelected ? 12 : 4,
                         x: 0,
                         y: isSelected ? 4 : 2
                     )
                     .scaleEffect(isSelected ? 1.2 : 1.0)
-                    .zIndex(isSelected ? 100 : 0)
                     .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isSelected)
             } else {
                 // Fallback: show category emoji in a Google-style filled circle
@@ -43,10 +41,6 @@ struct CustomPlaceAnnotationView: View {
                     Circle()
                         .fill(.white)
                         .frame(width: isSelected ? 46 : 38, height: isSelected ? 46 : 38)
-                        .overlay(
-                            Circle()
-                                .strokeBorder(.white, lineWidth: 2)
-                        )
                         .shadow(
                             color: Color.black.opacity(0.25),
                             radius: isSelected ? 6 : 4,

--- a/loc/Views/MainView.swift
+++ b/loc/Views/MainView.swift
@@ -313,6 +313,7 @@ struct MainView: View {
             .presentationBackground(Color.clear)
             .presentationBackgroundInteraction(.enabled(upThrough: .height(800)))
             .interactiveDismissDisabled(false)
+            .transaction { $0.animation = .spring(response: 0.25, dampingFraction: 0.9) }
     }
 
     /// External place selection sheet content.

--- a/loc/Views/MapView.swift
+++ b/loc/Views/MapView.swift
@@ -27,7 +27,6 @@ struct MapView: View {
     @State private var mapRefreshToggle = false
     @State private var showVisiblePlacesPopup = false
     @State private var currentMapRegion: MKCoordinateRegion?
-    @State private var hasLoadedInitialViewport = false
     @State private var hasCenteredOnUserLocation = false
     
     var onMapTap: ((CLLocationCoordinate2D) -> Void)?
@@ -75,6 +74,13 @@ struct MapView: View {
         }
     }
 
+    // Community markers filtered to exclude the currently selected place
+    private var filteredCommunityMarkers: [CommunityPlaceMarker] {
+        let selectedId = selectedPlaceVM.selectedPlace?.id.uuidString
+        guard let selectedId else { return mapViewModel.communityMarkers }
+        return mapViewModel.communityMarkers.filter { $0.id != selectedId }
+    }
+
     // Map content extracted to help Swift type checker
     private var mapContentView: some View {
         Map(position: $mapPosition) {
@@ -99,9 +105,7 @@ struct MapView: View {
                     // Hidden in "My Places" mode since community markers are not user-specific
                     // Filter out the community marker that's currently selected (to avoid duplicate with preserved annotation)
                     if !mapViewModel.showMyPlacesOnly {
-                        ForEach(mapViewModel.communityMarkers.filter { marker in
-                            selectedPlaceVM.selectedPlace?.id.uuidString != marker.id
-                        }) { marker in
+                        ForEach(filteredCommunityMarkers) { marker in
                             Annotation(
                                 "",
                                 coordinate: marker.coordinate,
@@ -236,6 +240,9 @@ struct MapView: View {
             return
         }
 
+        // Immediate haptic feedback on tap
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
         let place = mapViewModel.resolveAnnotationForNavigation(annotation)
         mapViewModel.setPreservedAnnotation(for: place)
         navigateToPlace(place)
@@ -334,15 +341,15 @@ struct MapView: View {
                     withAnimation(.easeInOut(duration: 0.5)) {
                         mapPosition = .camera(MapCamera(centerCoordinate: userLocation, distance: 1500))
                     }
-                    
-                    // Also load viewport places for this new location
-                    if !hasLoadedInitialViewport, let userId = profile.user?.id {
+
+                    // Pre-fetch annotations while camera animates — isRegionCovered prevents
+                    // duplicate fetch when onMapCameraChange(.onEnd) fires after animation
+                    if let userId = profile.user?.id {
                         let region = MKCoordinateRegion(
                             center: userLocation,
                             span: MKCoordinateSpan(latitudeDelta: 0.015, longitudeDelta: 0.015)
                         )
-                        hasLoadedInitialViewport = true
-                        Task.detached(priority: .background) {
+                        Task.detached(priority: .userInitiated) {
                             await mapViewModel.onMapCameraSettled(region, userId: userId)
                         }
                     }
@@ -414,14 +421,7 @@ struct MapView: View {
 
             // Setup notification observers
             setupNotificationObservers()
-            
-            // 🚀 Load initial viewport places (only if profile is ready)
-            if !hasLoadedInitialViewport, let region = currentMapRegion, let userId = profile.user?.id {
-                Task.detached(priority: .background) {
-                    await mapViewModel.onMapCameraSettled(region, userId: userId)
-                }
-                hasLoadedInitialViewport = true
-            }
+            // Viewport annotations load automatically via onMapCameraChange(.onEnd)
         }
          .onDisappear {
              // Remove notification observers
@@ -437,31 +437,9 @@ struct MapView: View {
             }
         }
         .task {
-            // 🚀 CRITICAL: Load viewport places FIRST (instant map rendering)
-            // Only proceed if user profile is available
+            // Load profile photos for annotation rendering
+            // Viewport annotations load via onMapCameraChange(.onEnd) — no need to duplicate here
             guard let userId = profile.user?.id else { return }
-            
-            if !hasLoadedInitialViewport {
-                // Give the map a moment to settle and provide a region
-                try? await Task.sleep(nanoseconds: 300_000_000) // 0.3 seconds
-                
-                if let region = currentMapRegion {
-                    await mapViewModel.onMapCameraSettled(region, userId: userId)
-                    hasLoadedInitialViewport = true
-                } else if let userLocation = locationManager.currentLocation?.coordinate {
-                    // Create a region from the user's current location
-                    let region = MKCoordinateRegion(
-                        center: userLocation,
-                        span: MKCoordinateSpan(latitudeDelta: 0.015, longitudeDelta: 0.015)
-                    )
-                    await mapViewModel.onMapCameraSettled(region, userId: userId)
-                    hasLoadedInitialViewport = true
-                }
-                // Note: If no location yet, we'll load viewport when location becomes available
-                // via the onChange handler
-            }
-            
-            // ✅ Load profile photos for annotations
             if !mapViewModel.hasLoadedPhotos {
                 await mapViewModel.loadFollowedUsersPhotos(
                     userId: userId,
@@ -470,30 +448,14 @@ struct MapView: View {
             }
         }
         .onChange(of: profile.user?.id) { oldValue, newValue in
-            // When user profile becomes available (nil → value), trigger initial loads
+            // When user profile becomes available (nil → value), load annotation photos
+            // Viewport annotations load via onMapCameraChange(.onEnd)
             guard let userId = newValue, oldValue == nil else { return }
-            
             Task {
-                // Load photos
                 await mapViewModel.loadFollowedUsersPhotos(
                     userId: userId,
                     currentUserPhotoUrl: profile.user?.profilePhotoURL
                 )
-                
-                // Load viewport if we have a region
-                if !hasLoadedInitialViewport {
-                    if let region = currentMapRegion {
-                        await mapViewModel.onMapCameraSettled(region, userId: userId)
-                        hasLoadedInitialViewport = true
-                    } else if let userLocation = locationManager.currentLocation?.coordinate {
-                        let region = MKCoordinateRegion(
-                            center: userLocation,
-                            span: MKCoordinateSpan(latitudeDelta: 0.015, longitudeDelta: 0.015)
-                        )
-                        await mapViewModel.onMapCameraSettled(region, userId: userId)
-                        hasLoadedInitialViewport = true
-                    }
-                }
             }
         }
         .sheet(isPresented: $showVisiblePlacesPopup) {

--- a/loc/Views/MapView.swift
+++ b/loc/Views/MapView.swift
@@ -16,6 +16,8 @@ struct MapView: View {
     @EnvironmentObject var mapViewModel: MapViewModel
     @EnvironmentObject var appCoordinator: AppCoordinator
     @EnvironmentObject var mapDisplayCoordinatorVM: MapDisplayCoordinatorViewModel
+    @EnvironmentObject var userProfileNavigationVM: UserProfileNavigationViewModel
+    @EnvironmentObject var userSession: UserSession
 
     @Binding var recenterMap: Bool
     @Binding var mapPosition: MapCameraPosition
@@ -461,6 +463,11 @@ struct MapView: View {
         .sheet(isPresented: $showVisiblePlacesPopup) {
             VisiblePlacesPopupView(mapRegion: currentMapRegion)
                 .environmentObject(selectedPlaceVM)
+                .environmentObject(profile)
+                .environmentObject(locationManager)
+                .environmentObject(detailPlaceVM)
+                .environmentObject(userProfileNavigationVM)
+                .environmentObject(userSession)
                 .presentationDragIndicator(.visible)
         }
         .onChange(of: selectedPlaceVM.selectedPlace?.id) { oldValue, newValue in

--- a/loc/Views/MapView/VisiblePlacesPopupView.swift
+++ b/loc/Views/MapView/VisiblePlacesPopupView.swift
@@ -31,26 +31,31 @@ struct VisiblePlacesPopupView: View {
     @EnvironmentObject private var profile: ProfileViewModel
     
     // MARK: - ViewModel (owned by this View)
-    
+
     @StateObject private var viewModel = VisiblePlacesPopupViewModel()
-    
+    @State private var navigationPath = NavigationPath()
+
     // MARK: - Layout
-    
+
     private let columns = [
         GridItem(.flexible(), spacing: 12),
         GridItem(.flexible(), spacing: 12)
     ]
-    
+
     // MARK: - Body
-    
+
     var body: some View {
-        NavigationView {
+        NavigationStack(path: $navigationPath) {
             VStack(spacing: 0) {
                 headerSection
                 filterPicker
                 contentSection
             }
             .navigationBarHidden(true)
+            .navigationDestination(for: String.self) { placeId in
+                PlaceDetailViewInNavigation(placeId: placeId, minSheetHeight: 250, shouldAnimateMap: true)
+                    .id(placeId)
+            }
         }
         .onAppear(perform: configureViewModel)
         .onChange(of: viewModel.selectedFilter) {
@@ -183,20 +188,8 @@ struct VisiblePlacesPopupView: View {
     
     // MARK: - Actions
     
-    /// Handle place tap - loads full details and navigates
+    /// Handle place tap — navigates to place detail within this sheet's navigation stack.
     private func handlePlaceTap(_ item: VisiblePlaceItem) {
-        Task {
-            do {
-                let fullPlace = try await viewModel.loadPlaceDetails(for: item)
-                
-            await MainActor.run {
-                selectedPlaceVM.selectPlaceAndFetchDetails(fullPlace, shouldAnimateMap: true)
-                selectedPlaceVM.isDetailSheetPresented = true
-                    dismiss()
-                }
-            } catch {
-                print("❌ [VisiblePlacesPopup] Error loading place details: \(error)")
-            }
-        }
+        navigationPath.append(item.id)
     }
 }

--- a/loc/Views/MyProfileViews/FullScreenListsView.swift
+++ b/loc/Views/MyProfileViews/FullScreenListsView.swift
@@ -1,0 +1,189 @@
+//
+//  FullScreenListsView.swift
+//  loc
+//
+//  Full-screen lists view with pinned search bar, filter chips, and pagination.
+//  Presented when the user taps the search bar on the profile lists section.
+//
+
+import SwiftUI
+
+/// Full-screen view for browsing and searching all place lists.
+struct FullScreenListsView: View {
+    @EnvironmentObject var profile: ProfileViewModel
+    @EnvironmentObject var selectedPlaceVM: SelectedPlaceViewModel
+    @EnvironmentObject var userSession: UserSession
+    @ObservedObject var listsVM: ProfileListsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var isSearchFocused: Bool
+
+    @State private var placeColors: [UUID: Color] = [:]
+    @State private var selectedListIndex: Int? = nil
+    @State private var showingNewListSheet = false
+    @State private var showingGoogleMapsImport = false
+    @State private var showingCreateTrip = false
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                searchHeader
+                    .padding(.top, 8)
+
+                filterAndActionsRow
+                    .padding(.top, 10)
+
+                Divider()
+                    .padding(.top, 8)
+
+                ScrollView {
+                    listContent
+                        .padding(.top, 12)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .navigationBarHidden(true)
+        }
+        .onAppear { isSearchFocused = true }
+        .sheet(isPresented: $showingNewListSheet) {
+            NewListSheetView(onSave: { listName in
+                let _ = await profile.listsViewModel.addNewPlaceList(named: listName, city: "", emoji: "", image: "")
+            })
+            .presentationDetents([.height(200)])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showingGoogleMapsImport) {
+            GoogleMapsImportView(
+                userId: profile.user?.id ?? "",
+                onImportCompleted: { listId in
+                    Task {
+                        await listsVM.reloadListsAfterSearch()
+                        if let index = listsVM.filteredPlaceLists.firstIndex(where: { $0.list_id == listId }) {
+                            selectedListIndex = index
+                        }
+                    }
+                }
+            )
+        }
+        .fullScreenCover(isPresented: $showingCreateTrip) {
+            CreateTripView { _ in showingCreateTrip = false }
+                .environmentObject(userSession)
+        }
+        .sheet(item: Binding<ListCardIndex?>(
+            get: { selectedListIndex.map { ListCardIndex(value: $0) } },
+            set: { selectedListIndex = $0?.value }
+        )) { item in
+            LightweightListPopupView(
+                lists: listsVM.filteredPlaceLists,
+                initialListIndex: item.value,
+                listsVM: listsVM,
+                reviewsVM: profile.reviewsViewModel,
+                onViewOnMap: {
+                    let listId = listsVM.filteredPlaceLists[item.value].list_id
+                    selectedListIndex = nil
+                    profile.selectedListIdForMap = listId
+                    dismiss()
+                }
+            )
+        }
+    }
+
+    // MARK: - Search Header
+
+    private var searchHeader: some View {
+        ListsSearchBar(
+            searchText: Binding(
+                get: { listsVM.listSearchText },
+                set: { listsVM.listSearchText = $0 }
+            ),
+            isFocused: $isSearchFocused,
+            onCancel: {
+                listsVM.listSearchText = ""
+                isSearchFocused = false
+                dismiss()
+            }
+        )
+    }
+
+    // MARK: - Filter & Actions Row
+
+    private var filterAndActionsRow: some View {
+        HStack {
+            HStack(spacing: 8) {
+                FilterChip(
+                    label: "All",
+                    isSelected: !listsVM.showOnlySharedLists,
+                    onTap: { listsVM.showOnlySharedLists = false }
+                )
+                FilterChip(
+                    label: "Shared",
+                    isSelected: listsVM.showOnlySharedLists,
+                    onTap: { listsVM.showOnlySharedLists = true }
+                )
+            }
+
+            Spacer()
+
+            ListActionsMenu(
+                onAddList: { showingNewListSheet = true },
+                onCreateTrip: { showingCreateTrip = true },
+                onImportGoogleMaps: { showingGoogleMapsImport = true }
+            )
+        }
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - List Content
+
+    @ViewBuilder
+    private var listContent: some View {
+        let hasSearchText = !listsVM.listSearchText.trimmingCharacters(in: .whitespaces).isEmpty
+        if listsVM.isLoadingInitialLists && !hasSearchText {
+            loadingView
+        } else if !listsVM.filteredPlaceLists.isEmpty {
+            ListCardGrid(
+                listsVM: listsVM,
+                placeColors: $placeColors,
+                userId: profile.user?.id ?? "",
+                onListTap: { index in
+                    isSearchFocused = false
+                    selectedListIndex = index
+                }
+            )
+        } else if hasSearchText {
+            noResultsView
+        } else {
+            emptyView
+        }
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+            Text("Loading lists...")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    private var noResultsView: some View {
+        VStack(spacing: 8) {
+            Text("No matching lists")
+                .font(.subheadline)
+                .foregroundColor(.gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 30)
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 12) {
+            CreateListTileView(onTap: { showingNewListSheet = true })
+        }
+        .padding(.horizontal, 16)
+    }
+}

--- a/loc/Views/MyProfileViews/LightweightProfileListSection.swift
+++ b/loc/Views/MyProfileViews/LightweightProfileListSection.swift
@@ -26,7 +26,7 @@ struct LightweightProfileListSection: View {
     var body: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 8) {
-                ListCardImage(places: places, placeColors: $placeColors)
+                ListCardImage(list: list, places: places, placeColors: $placeColors)
 
                 ListCardInfo(
                     list: list,
@@ -42,12 +42,15 @@ struct LightweightProfileListSection: View {
 /// Square image card for list preview - NO GeometryReader needed!
 /// Uses aspectRatio(1, ...) for stable sizing in LazyVGrid.
 private struct ListCardImage: View {
+    let list: LightweightPlaceList
     let places: [LightweightPlace]
     @Binding var placeColors: [UUID: Color]
-    
+
     var body: some View {
-        Group {
-            if !places.isEmpty {
+        ZStack {
+            if let previewPhotos = list.preview_photos, !previewPhotos.isEmpty {
+                PreviewPhotoCollage(photoURLs: previewPhotos)
+            } else if !places.isEmpty {
                 ListPhotoCollage(
                     places: Array(places.prefix(3)),
                     placeColors: $placeColors
@@ -56,8 +59,9 @@ private struct ListCardImage: View {
                 EmptyListCard()
             }
         }
-        .aspectRatio(1, contentMode: .fit) // This makes it square - no measurement needed!
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .aspectRatio(3.0/4.0, contentMode: .fit)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.08), radius: 6, x: 0, y: 3)
     }
 }

--- a/loc/Views/MyProfileViews/ListsSearchBar.swift
+++ b/loc/Views/MyProfileViews/ListsSearchBar.swift
@@ -19,6 +19,7 @@ struct ListsSearchBar: View {
     var isFilterEnabled: Bool
     var onToggleFilter: () -> Void
     var onAddList: () -> Void
+    var onCreateTrip: () -> Void
     var onImportGoogleMapsList: () -> Void
 
     // MARK: - Body
@@ -111,6 +112,11 @@ struct ListsSearchBar: View {
                 onAddList()
             } label: {
                 Label("New List", systemImage: "plus")
+            }
+            Button {
+                onCreateTrip()
+            } label: {
+                Label("New Trip", systemImage: "airplane")
             }
             Button {
                 onImportGoogleMapsList()

--- a/loc/Views/MyProfileViews/ListsSearchBar.swift
+++ b/loc/Views/MyProfileViews/ListsSearchBar.swift
@@ -2,10 +2,8 @@
 //  ListsSearchBar.swift
 //  loc
 //
-//  DUMB Component: Unified search bar combining shared filter, search field, and add list menu
-//  Single Responsibility: Render the lists search/filter bar UI based on passed-in state
-//
-//  Layout: [Shared circle btn] [Search capsule w/ TextField] [Plus circle menu]
+//  DUMB Component: Search bar with text field and cancel button.
+//  Single Responsibility: Render the search input with dismiss capability.
 //
 
 import SwiftUI
@@ -14,62 +12,17 @@ struct ListsSearchBar: View {
     // MARK: - Parameters
 
     @Binding var searchText: String
-    var showOnlyShared: Bool
-    var hasSharedLists: Bool
-    var isFilterEnabled: Bool
-    var onToggleFilter: () -> Void
-    var onAddList: () -> Void
-    var onCreateTrip: () -> Void
-    var onImportGoogleMapsList: () -> Void
+    var isFocused: FocusState<Bool>.Binding
+    var onCancel: () -> Void
 
     // MARK: - Body
 
     var body: some View {
         HStack(spacing: 10) {
-            if hasSharedLists || !isFilterEnabled {
-                sharedButton
-            }
             searchCapsule
-            plusMenu
+            cancelButton
         }
         .padding(.horizontal, 20)
-    }
-
-    // MARK: - Shared Filter Button
-
-    private var sharedButton: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                onToggleFilter()
-            }
-        } label: {
-            Group {
-                if !isFilterEnabled {
-                    ProgressView()
-                        .scaleEffect(0.6)
-                        .frame(width: 16, height: 16)
-                } else {
-                    Image(systemName: showOnlyShared ? "person.2.fill" : "person.2")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(showOnlyShared ? .white : .primary)
-                }
-            }
-            .frame(width: 36, height: 36)
-            .background(
-                Circle()
-                    .fill(sharedButtonBackground)
-            )
-        }
-        .frame(minWidth: 44, minHeight: 44)
-        .contentShape(Circle())
-        .disabled(!isFilterEnabled)
-    }
-
-    private var sharedButtonBackground: Color {
-        if !isFilterEnabled {
-            return Color(.systemGray5).opacity(0.6)
-        }
-        return showOnlyShared ? Color.primary : Color(.systemGray5).opacity(0.6)
     }
 
     // MARK: - Search Capsule
@@ -85,6 +38,7 @@ struct ListsSearchBar: View {
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .submitLabel(.search)
+                .focused(isFocused)
 
             if !searchText.isEmpty {
                 Button {
@@ -104,36 +58,13 @@ struct ListsSearchBar: View {
         )
     }
 
-    // MARK: - Plus Menu
+    // MARK: - Cancel Button
 
-    private var plusMenu: some View {
-        Menu {
-            Button {
-                onAddList()
-            } label: {
-                Label("New List", systemImage: "plus")
-            }
-            Button {
-                onCreateTrip()
-            } label: {
-                Label("New Trip", systemImage: "airplane")
-            }
-            Button {
-                onImportGoogleMapsList()
-            } label: {
-                Label("Import from Google Maps", systemImage: "map")
-            }
-        } label: {
-            Image(systemName: "plus")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.primary)
-                .frame(width: 36, height: 36)
-                .background(
-                    Circle()
-                        .fill(Color(.systemGray5).opacity(0.6))
-                )
+    private var cancelButton: some View {
+        Button("Cancel") {
+            onCancel()
         }
-        .frame(minWidth: 44, minHeight: 44)
-        .contentShape(Circle())
+        .font(.subheadline)
+        .foregroundColor(.primary)
     }
 }

--- a/loc/Views/MyProfileViews/ProfileViewListsView.swift
+++ b/loc/Views/MyProfileViews/ProfileViewListsView.swift
@@ -2,58 +2,44 @@
 //  ProfileViewListsView.swift
 //  loc
 //
-//  DUMB Component: Displays user's place lists with filter and pagination
-//  Single Responsibility: Render list UI based on ViewModel state
-//
-//  Reactively displays:
-//  - Loading state (while initial fetch in progress)
-//  - Filtered lists (all or shared-only based on filter)
-//  - Empty states (no lists vs no shared lists)
-//  - Pagination loading indicator
+//  DUMB Component: Displays user's place lists with preview cards and a search tap target.
+//  Tapping the search bar opens FullScreenListsView for dedicated search and browsing.
 //
 //  Created by Andrew Hartsfield II on 12/14/24.
 //
 
 import SwiftUI
-import PhotosUI
-
-/// Identifiable wrapper for Int index, used for sheet(item:) presentation.
-private struct IdentifiableIndex: Identifiable {
-    let value: Int
-    var id: Int { value }
-}
 
 struct ProfileViewListsView: View {
     @EnvironmentObject var profile: ProfileViewModel
     @EnvironmentObject var selectedPlaceVM: SelectedPlaceViewModel
-    @EnvironmentObject var detailPlaceViewModel: DetailPlaceViewModel
     @EnvironmentObject var deepLinkManager: DeepLinkManager
     @EnvironmentObject var userSession: UserSession
     @ObservedObject var listsVM: ProfileListsViewModel
     @Environment(\.presentationMode) private var presentationMode
 
-    @State private var showingImagePicker = false
-    @State private var inputImage: [UIImage] = []
-    @State private var selectedList: PlaceListViewModel?
-    @State private var showingNewListSheet = false
     @State private var placeColors: [UUID: Color] = [:]
-    @State private var listToDelete: LightweightPlaceList?
-    @State private var showDeleteConfirmation = false
+    @State private var showFullScreenLists = false
+    @State private var showingNewListSheet = false
+    @State private var showingCreateTrip = false
+    @State private var showingGoogleMapsImport = false
     @State private var selectedListIndex: Int? = nil
     @State private var pendingMapListId: String? = nil
-    @State private var showingGoogleMapsImport = false
-    @State private var showingCreateTrip = false
-    @StateObject private var shareCardVM = ListStoryCardViewModel()
+
+    private let listColumns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
 
     // MARK: - Body
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            listsSearchBar
+            searchBarTapTarget
             listContent
         }
-        .sheet(isPresented: $showingImagePicker) {
-            ImagePicker(images: $inputImage, selectionLimit: 1)
+        .fullScreenCover(isPresented: $showFullScreenLists) {
+            FullScreenListsView(listsVM: listsVM)
         }
         .sheet(isPresented: $showingNewListSheet) {
             NewListSheetView(onSave: { listName in
@@ -65,22 +51,14 @@ struct ProfileViewListsView: View {
         .sheet(isPresented: $showingGoogleMapsImport) {
             GoogleMapsImportView(
                 userId: profile.user?.id ?? "",
-                onImportCompleted: { listId in
-                    Task {
-                        await listsVM.reloadListsAfterSearch()
-                        // Open the newly created list
-                        if let index = listsVM.filteredPlaceLists.firstIndex(where: { $0.list_id == listId }) {
-                            selectedListIndex = index
-                        }
-                    }
+                onImportCompleted: { _ in
+                    Task { await listsVM.reloadListsAfterSearch() }
                 }
             )
         }
         .fullScreenCover(isPresented: $showingCreateTrip) {
-            CreateTripView { _ in
-                showingCreateTrip = false
-            }
-            .environmentObject(userSession)
+            CreateTripView { _ in showingCreateTrip = false }
+                .environmentObject(userSession)
         }
         .sheet(isPresented: .constant(deepLinkManager.hasPendingList()), onDismiss: {
             deepLinkManager.clearPendingList()
@@ -100,30 +78,21 @@ struct ProfileViewListsView: View {
                 presentationMode.wrappedValue.dismiss()
             }
         }
-        .alert("Delete List", isPresented: $showDeleteConfirmation) {
-            Button("Cancel", role: .cancel) {
-                listToDelete = nil
-            }
-            Button("Delete", role: .destructive) {
-                if let list = listToDelete {
-                    Task {
-                        let result = await profile.listsViewModel.deleteLightweightList(list)
-                        if case .failure = result {
-                            // Could show error alert here if needed
-                        }
-                        listToDelete = nil
-                    }
-                }
-            }
-        } message: {
-            if let list = listToDelete {
-                Text("Are you sure you want to delete \"\(list.name)\"? This action cannot be undone.")
+        .onChange(of: profile.selectedListIdForMap) { _, newValue in
+            if newValue != nil {
+                showFullScreenLists = false
+                presentationMode.wrappedValue.dismiss()
             }
         }
-        .sheet(item: Binding<IdentifiableIndex?>(
-            get: { selectedListIndex.map { IdentifiableIndex(value: $0) } },
+        .sheet(item: Binding<ListCardIndex?>(
+            get: { selectedListIndex.map { ListCardIndex(value: $0) } },
             set: { selectedListIndex = $0?.value }
-        ), onDismiss: handleListPopupDismiss) { item in
+        ), onDismiss: {
+            guard let listId = pendingMapListId else { return }
+            pendingMapListId = nil
+            profile.selectedListIdForMap = listId
+            presentationMode.wrappedValue.dismiss()
+        }) { item in
             LightweightListPopupView(
                 lists: listsVM.filteredPlaceLists,
                 initialListIndex: item.value,
@@ -136,51 +105,59 @@ struct ProfileViewListsView: View {
             )
         }
     }
-    
-    // MARK: - Lists Search Bar
 
-    private var listsSearchBar: some View {
-        ListsSearchBar(
-            searchText: Binding(
-                get: { listsVM.listSearchText },
-                set: { listsVM.listSearchText = $0 }
-            ),
-            showOnlyShared: listsVM.showOnlySharedLists,
-            hasSharedLists: listsVM.hasSharedLists,
-            isFilterEnabled: listsVM.canInteractWithSharedFilter,
-            onToggleFilter: {
-                listsVM.showOnlySharedLists.toggle()
-            },
-            onAddList: {
-                showingNewListSheet = true
-            },
-            onCreateTrip: {
-                showingCreateTrip = true
-            },
-            onImportGoogleMapsList: {
-                showingGoogleMapsImport = true
+    // MARK: - Search Bar Tap Target
+
+    /// Non-editable search bar that opens the full-screen lists view when tapped.
+    private var searchBarTapTarget: some View {
+        HStack(spacing: 10) {
+            Button { showFullScreenLists = true } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.gray)
+                        .font(.system(size: 14))
+
+                    Text("Search lists...")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule()
+                        .fill(Color(.systemGray5).opacity(0.6))
+                )
             }
-        )
+
+            ListActionsMenu(
+                onAddList: { showingNewListSheet = true },
+                onCreateTrip: { showingCreateTrip = true },
+                onImportGoogleMaps: { showingGoogleMapsImport = true }
+            )
+        }
+        .padding(.horizontal, 20)
     }
-    
-    // MARK: - List Content (State-based rendering)
-    
+
+    // MARK: - List Content
+
     @ViewBuilder
     private var listContent: some View {
-        let hasSearchText = !listsVM.listSearchText.trimmingCharacters(in: .whitespaces).isEmpty
-        if listsVM.isLoadingInitialLists && !hasSearchText {
+        if listsVM.isLoadingInitialLists {
             initialLoadingView
         } else if !listsVM.filteredPlaceLists.isEmpty {
-            listView
-        } else if hasSearchText {
-            noSearchResultsView
+            ListCardGrid(
+                listsVM: listsVM,
+                placeColors: $placeColors,
+                userId: profile.user?.id ?? "",
+                onListTap: { index in selectedListIndex = index }
+            )
         } else {
-            emptyStateView
+            createListTile
         }
     }
-    
-    // MARK: - Initial Loading View
-    
+
     private var initialLoadingView: some View {
         VStack(spacing: 12) {
             ProgressView()
@@ -191,153 +168,11 @@ struct ProfileViewListsView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 40)
     }
-    
-    // MARK: - List View
 
-    // 2-column grid for displaying lists side by side
-    private let listColumns = [
-        GridItem(.flexible(), spacing: 12),
-        GridItem(.flexible(), spacing: 12)
-    ]
-
-    private var listView: some View {
+    private var createListTile: some View {
         LazyVGrid(columns: listColumns, spacing: 16) {
-            ForEach(Array(listsVM.filteredPlaceLists.enumerated()), id: \.element.id) { index, list in
-                LightweightProfileListSection(
-                    list: list,
-                    places: listsVM.lightweightPlaceListPlaces[list.list_id] ?? [],
-                    allLists: listsVM.filteredPlaceLists,
-                    currentIndex: index,
-                    placeCount: listsVM.lightweightPlaceListCounts[list.list_id] ?? list.place_count,
-                    placeColors: $placeColors,
-                    onTap: { selectedListIndex = index }
-                )
-                .contextMenu {
-                    Button {
-                        Task {
-                            await shareCardVM.quickShare(
-                                list: list,
-                                places: listsVM.lightweightPlaceListPlaces[list.list_id] ?? [],
-                                userId: profile.user?.id ?? "",
-                                shareService: ServiceContainer.shared.placeShareService
-                            )
-                        }
-                    } label: {
-                        Label("Share List", systemImage: "square.and.arrow.up")
-                    }
-                    Button(role: .destructive) {
-                        listToDelete = list
-                        showDeleteConfirmation = true
-                    } label: {
-                        Label("Delete List", systemImage: "trash")
-                    }
-                }
-                .onAppear {
-                    handleListAppear(list: list)
-                }
-            }
-
-            // Pagination trigger - always present at end of list to catch fast scrolling
-            if listsVM.hasMorePlaceLists && !listsVM.isLoadingMorePlaceLists {
-                Color.clear
-                    .frame(height: 1)
-                    .onAppear {
-                        Task {
-                            await listsVM.loadMoreLists()
-                        }
-                    }
-            }
-
-            // Pagination loading indicator
-            if listsVM.isLoadingMorePlaceLists {
-                paginationLoadingView
-            }
+            CreateListTileView(onTap: { showingNewListSheet = true })
         }
         .padding(.horizontal, 16)
-    }
-    
-    // MARK: - Empty State View
-    
-    private var emptyStateView: some View {
-        Group {
-            if listsVM.showOnlySharedLists {
-                noSharedListsView
-            } else {
-                createListTileGrid
-            }
-        }
-    }
-    
-    private var noSearchResultsView: some View {
-        VStack(spacing: 8) {
-            Text("No matching lists")
-                .font(.subheadline)
-                .foregroundColor(.gray)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 30)
-    }
-
-    private var noSharedListsView: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "person.2")
-                .font(.system(size: 32))
-                .foregroundColor(.gray.opacity(0.5))
-            Text("No shared lists")
-                .font(.subheadline)
-                .foregroundColor(.gray)
-            Text("Lists shared with you or that you've shared will appear here")
-                .font(.caption)
-                .foregroundColor(.gray.opacity(0.7))
-                .multilineTextAlignment(.center)
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 20)
-    }
-    
-    private var createListTileGrid: some View {
-        LazyVGrid(columns: listColumns, spacing: 16) {
-            CreateListTileView(onTap: {
-                showingNewListSheet = true
-            })
-        }
-        .padding(.horizontal, 16)
-    }
-    
-    // MARK: - Pagination Loading View
-    
-    private var paginationLoadingView: some View {
-        HStack {
-            Spacer()
-            ProgressView()
-                .padding()
-            Spacer()
-        }
-    }
-    
-    // MARK: - Actions
-
-    /// Called when list popup sheet is dismissed - navigates to map if user tapped "Map".
-    private func handleListPopupDismiss() {
-        guard let listId = pendingMapListId else { return }
-        pendingMapListId = nil
-        profile.selectedListIdForMap = listId
-        presentationMode.wrappedValue.dismiss()
-    }
-
-    /// Handle list appearing - triggers pagination when approaching end
-    private func handleListAppear(list: LightweightPlaceList) {
-        // Don't paginate during search or shared filter
-        guard !listsVM.showOnlySharedLists && listsVM.listSearchText.isEmpty else { return }
-
-        if listsVM.shouldLoadMoreLists(
-            currentItem: list,
-            filteredLists: listsVM.filteredPlaceLists,
-            isSearching: !listsVM.listSearchText.isEmpty
-        ) {
-            Task {
-                await listsVM.loadMoreLists()
-            }
-        }
     }
 }

--- a/loc/Views/MyProfileViews/ProfileViewListsView.swift
+++ b/loc/Views/MyProfileViews/ProfileViewListsView.swift
@@ -28,6 +28,7 @@ struct ProfileViewListsView: View {
     @EnvironmentObject var selectedPlaceVM: SelectedPlaceViewModel
     @EnvironmentObject var detailPlaceViewModel: DetailPlaceViewModel
     @EnvironmentObject var deepLinkManager: DeepLinkManager
+    @EnvironmentObject var userSession: UserSession
     @ObservedObject var listsVM: ProfileListsViewModel
     @Environment(\.presentationMode) private var presentationMode
 
@@ -41,6 +42,7 @@ struct ProfileViewListsView: View {
     @State private var selectedListIndex: Int? = nil
     @State private var pendingMapListId: String? = nil
     @State private var showingGoogleMapsImport = false
+    @State private var showingCreateTrip = false
     @StateObject private var shareCardVM = ListStoryCardViewModel()
 
     // MARK: - Body
@@ -73,6 +75,12 @@ struct ProfileViewListsView: View {
                     }
                 }
             )
+        }
+        .fullScreenCover(isPresented: $showingCreateTrip) {
+            CreateTripView { _ in
+                showingCreateTrip = false
+            }
+            .environmentObject(userSession)
         }
         .sheet(isPresented: .constant(deepLinkManager.hasPendingList()), onDismiss: {
             deepLinkManager.clearPendingList()
@@ -145,6 +153,9 @@ struct ProfileViewListsView: View {
             },
             onAddList: {
                 showingNewListSheet = true
+            },
+            onCreateTrip: {
+                showingCreateTrip = true
             },
             onImportGoogleMapsList: {
                 showingGoogleMapsImport = true

--- a/loc/Views/ReusableViews/PreviewPhotoCollage.swift
+++ b/loc/Views/ReusableViews/PreviewPhotoCollage.swift
@@ -1,0 +1,53 @@
+//
+//  PreviewPhotoCollage.swift
+//  loc
+//
+//  DUMB Component: Shows up to 3 preview photos in a collage layout.
+//  Uses photo URLs embedded in list metadata — no per-list place fetch needed.
+//
+
+import SwiftUI
+
+/// Photo collage using pre-fetched preview URLs from list metadata.
+struct PreviewPhotoCollage: View {
+    let photoURLs: [String]
+
+    var body: some View {
+        switch photoURLs.count {
+        case 0:
+            Color(.systemGray6)
+        case 1:
+            CollageCell(urlString: photoURLs[0])
+        case 2:
+            HStack(spacing: 1.5) {
+                CollageCell(urlString: photoURLs[0])
+                CollageCell(urlString: photoURLs[1])
+            }
+        default:
+            HStack(spacing: 1.5) {
+                VStack(spacing: 1.5) {
+                    CollageCell(urlString: photoURLs[0])
+                    CollageCell(urlString: photoURLs[1])
+                }
+                CollageCell(urlString: photoURLs[2])
+            }
+        }
+    }
+}
+
+/// Single cell in a preview photo collage — fills and clips within layout bounds.
+private struct CollageCell: View {
+    let urlString: String
+
+    var body: some View {
+        Color(.systemGray6)
+            .overlay(
+                CachedAsyncImage(url: URL(string: urlString), targetSize: nil) {
+                    Color(.systemGray6)
+                }
+                .scaledToFill()
+            )
+            .clipped()
+            .contentShape(Rectangle())
+    }
+}

--- a/loc/Views/ReusableViews/ProfileListCard.swift
+++ b/loc/Views/ReusableViews/ProfileListCard.swift
@@ -44,8 +44,10 @@ struct ProfileListCard: View {
     // MARK: - List Card Image
 
     private var listCardImage: some View {
-        Group {
-            if !places.isEmpty {
+        ZStack {
+            if let previewPhotos = list.preview_photos, !previewPhotos.isEmpty {
+                PreviewPhotoCollage(photoURLs: previewPhotos)
+            } else if !places.isEmpty {
                 ListPhotoCollage(
                     places: Array(places.prefix(3)),
                     placeColors: $placeColors
@@ -54,8 +56,9 @@ struct ProfileListCard: View {
                 emptyListCard
             }
         }
-        .aspectRatio(1, contentMode: .fit)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .aspectRatio(3.0/4.0, contentMode: .fit)
+        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .shadow(color: .black.opacity(0.08), radius: 6, x: 0, y: 3)
     }
 

--- a/loc/Views/SharedComponents/FilterChip.swift
+++ b/loc/Views/SharedComponents/FilterChip.swift
@@ -1,0 +1,31 @@
+//
+//  FilterChip.swift
+//  loc
+//
+//  DUMB Component: Google-style filter chip with selected/unselected states.
+//  Single Responsibility: Render a labeled, tappable filter pill.
+//
+
+import SwiftUI
+
+/// Google-style filter chip for category/filter selection.
+struct FilterChip: View {
+    let label: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(label)
+                .font(.subheadline)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .foregroundColor(isSelected ? .white : .primary)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? Color.primary : Color(.systemGray6))
+                )
+        }
+    }
+}

--- a/loc/Views/SharedComponents/ListActionsMenu.swift
+++ b/loc/Views/SharedComponents/ListActionsMenu.swift
@@ -1,0 +1,41 @@
+//
+//  ListActionsMenu.swift
+//  loc
+//
+//  DUMB Component: Plus menu for creating lists, trips, and importing.
+//  Reused by ProfileViewListsView and FullScreenListsView.
+//
+
+import SwiftUI
+
+/// Plus button menu with list creation, trip creation, and import actions.
+struct ListActionsMenu: View {
+    let onAddList: () -> Void
+    let onCreateTrip: () -> Void
+    let onImportGoogleMaps: () -> Void
+
+    var body: some View {
+        Menu {
+            Button { onAddList() } label: {
+                Label("New List", systemImage: "plus")
+            }
+            Button { onCreateTrip() } label: {
+                Label("New Trip", systemImage: "airplane")
+            }
+            Button { onImportGoogleMaps() } label: {
+                Label("Import from Google Maps", systemImage: "map")
+            }
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.primary)
+                .frame(width: 36, height: 36)
+                .background(
+                    Circle()
+                        .fill(Color(.systemGray6))
+                )
+        }
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Circle())
+    }
+}

--- a/loc/Views/SharedComponents/ListCardGrid.swift
+++ b/loc/Views/SharedComponents/ListCardGrid.swift
@@ -1,0 +1,110 @@
+//
+//  ListCardGrid.swift
+//  loc
+//
+//  DUMB Component: Renders a 2-column grid of list cards with pagination.
+//  Reused by both ProfileViewListsView and FullScreenListsView.
+//
+
+import SwiftUI
+
+/// Identifiable wrapper for Int index, used for sheet(item:) presentation.
+struct ListCardIndex: Identifiable {
+    let value: Int
+    var id: Int { value }
+}
+
+/// 2-column grid of list cards with context menus and pagination.
+struct ListCardGrid: View {
+    @ObservedObject var listsVM: ProfileListsViewModel
+    @Binding var placeColors: [UUID: Color]
+    let userId: String
+    let onListTap: (Int) -> Void
+
+    @StateObject private var shareCardVM = ListStoryCardViewModel()
+    @State private var listToDelete: LightweightPlaceList?
+    @State private var showDeleteConfirmation = false
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 16) {
+            ForEach(Array(listsVM.filteredPlaceLists.enumerated()), id: \.element.id) { index, list in
+                LightweightProfileListSection(
+                    list: list,
+                    places: listsVM.lightweightPlaceListPlaces[list.list_id] ?? [],
+                    allLists: listsVM.filteredPlaceLists,
+                    currentIndex: index,
+                    placeCount: listsVM.lightweightPlaceListCounts[list.list_id] ?? list.place_count,
+                    placeColors: $placeColors,
+                    onTap: { onListTap(index) }
+                )
+                .contextMenu {
+                    Button {
+                        Task {
+                            await shareCardVM.quickShare(
+                                list: list,
+                                places: listsVM.lightweightPlaceListPlaces[list.list_id] ?? [],
+                                userId: userId,
+                                shareService: ServiceContainer.shared.placeShareService
+                            )
+                        }
+                    } label: {
+                        Label("Share List", systemImage: "square.and.arrow.up")
+                    }
+                    Button(role: .destructive) {
+                        listToDelete = list
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete List", systemImage: "trash")
+                    }
+                }
+                .onAppear {
+                    guard listsVM.listSearchText.isEmpty, !listsVM.showOnlySharedLists else { return }
+                    if listsVM.shouldLoadMoreLists(
+                        currentItem: list,
+                        filteredLists: listsVM.filteredPlaceLists,
+                        isSearching: false
+                    ) {
+                        Task { await listsVM.loadMoreLists() }
+                    }
+                }
+            }
+
+            if listsVM.hasMorePlaceLists && !listsVM.isLoadingMorePlaceLists {
+                Color.clear
+                    .frame(height: 1)
+                    .onAppear {
+                        Task { await listsVM.loadMoreLists() }
+                    }
+            }
+
+            if listsVM.isLoadingMorePlaceLists {
+                HStack {
+                    Spacer()
+                    ProgressView().padding()
+                    Spacer()
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .alert("Delete List", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { listToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let list = listToDelete {
+                    Task {
+                        _ = await listsVM.deleteLightweightList(list)
+                        listToDelete = nil
+                    }
+                }
+            }
+        } message: {
+            if let list = listToDelete {
+                Text("Are you sure you want to delete \"\(list.name)\"? This action cannot be undone.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Cache map annotations across viewport scrolls — no re-fetching previously loaded areas
- Fix stuck annotation highlight on sheet dismiss
- Reduce annotation shadows (4→1) and merge images incrementally for smoother panning
- Consolidate viewport loading to single onMapCameraChange path with early pre-fetch
- Embed preview photos in list RPCs — eliminates N+1 per-list place fetching
- Instant local list search with pre-fetched metadata cache
- Full-screen lists view with filter chips, shared components (ListCardGrid, FilterChip, ListActionsMenu)
- In-hierarchy place detail navigation from places-in-view sheet
- Faster sheet presentation spring, haptic feedback on annotation tap
- Clear stale data on place transition to prevent flash
- Add trip creation to profile + menu
- Page size 6→12, taller 3:4 list card aspect ratio

## Test plan
- [x] Pan map — annotations persist, no re-fetch when returning to loaded areas
- [x] Tap annotation — highlights, detail sheet opens fast, de-highlights on dismiss
- [x] Profile lists load with cover photos immediately (no N+1)
- [x] Tap search bar on profile → full-screen lists with filter chips
- [x] Search lists → instant local filtering
- [x] Places-in-view → tap place → detail opens within sheet hierarchy
- [x] View on Map from full-screen lists → dismisses all layers, shows on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)